### PR TITLE
Harden user-visible boundaries against hostile/MITM'd source data

### DIFF
--- a/tests/test_base_helpers.py
+++ b/tests/test_base_helpers.py
@@ -221,3 +221,42 @@ def test_https_get_detects_redirect_loop(th):
     with patch("torrent_hound.sources.base._requests.get", side_effect=fake_get):
         with pytest.raises(requests.TooManyRedirects):
             th.sources.base._https_get("https://example.com/a")
+
+
+def test_https_get_refuses_cross_host_http_redirect(th):
+    """A mirror redirecting `Location: http://attacker.example/...` must
+    NOT be silently rewritten to `https://attacker.example/...` — the
+    earlier unconditional rewrite let a hostile mirror redirect us at
+    any host of its choosing. Same-host http→https rewrite is the only
+    documented use case (TPB) and is allowed by a separate test."""
+    from unittest.mock import patch
+
+    import pytest
+    import requests
+
+    def fake_get(url, **kwargs):
+        return _mk_resp(302, location="http://attacker.example/landing")
+
+    with patch("torrent_hound.sources.base._requests.get", side_effect=fake_get):
+        with pytest.raises(requests.exceptions.InvalidURL, match="cross-host"):
+            th.sources.base._https_get("https://thepiratebay.org/start")
+
+
+def test_https_get_allows_cross_host_https_redirect(th):
+    """Cross-host hops over https are legitimate (yts.lt → yts.bz)."""
+    from unittest.mock import patch
+    seen = []
+
+    def fake_get(url, **kwargs):
+        seen.append(url)
+        if "yts.lt" in url:
+            return _mk_resp(302, location="https://yts.bz/api/v2/list_movies.json")
+        return _mk_resp(200)
+
+    with patch("torrent_hound.sources.base._requests.get", side_effect=fake_get):
+        th.sources.base._https_get("https://yts.lt/api/v2/list_movies.json")
+
+    assert seen == [
+        "https://yts.lt/api/v2/list_movies.json",
+        "https://yts.bz/api/v2/list_movies.json",
+    ]

--- a/tests/test_eztv.py
+++ b/tests/test_eztv.py
@@ -2,6 +2,7 @@
 episode/keyword filtering, domain fallback, and error handling."""
 from unittest.mock import MagicMock, patch
 
+import pytest
 import requests
 
 # ---------------------------------------------------------------------------
@@ -494,3 +495,100 @@ def test_searchEZTV_shows_error_when_all_domains_fail(th, capsys):
         results = th.searchEZTV("severance")
         assert results == []
         assert "unreachable" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# Security: M1 — magnet_url scheme allowlist
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("bad_url", [
+    "",
+    "file:///etc/passwd",
+    "javascript:alert(1)",
+    "https://attacker.example/x",
+    "slack://team/x",
+    "magnet-not-really:?xt=...",
+])
+def test_parse_eztv_json_drops_torrents_with_non_magnet_url(th, bad_url):
+    """The TUI's `c`/`d`/`cs` actions hand `entry["magnet"]` to pyperclip
+    or webbrowser.open. A hostile mirror must not be able to ride a
+    `file://` / `javascript:` / vendor-URI into either path via the
+    EZTV JSON's `magnet_url` field."""
+    torrents = [
+        {
+            "id": "1", "title": "evil", "magnet_url": bad_url,
+            "season": "1", "episode": "1",
+            "seeds": 10, "peers": 1, "size_bytes": 1024,
+        },
+    ]
+    assert th._parse_eztv_json(torrents) == []
+
+
+def test_parse_eztv_json_keeps_valid_magnets(th):
+    valid = "magnet:?xt=urn:btih:" + ("a" * 40)
+    torrents = [{
+        "id": "1", "title": "ok", "magnet_url": valid,
+        "season": "1", "episode": "1",
+        "seeds": 10, "peers": 1, "size_bytes": 1024,
+    }]
+    out = th._parse_eztv_json(torrents)
+    assert len(out) == 1 and out[0]["magnet"] == valid
+
+
+def test_parse_eztv_json_drops_when_magnet_url_missing(th):
+    torrents = [{
+        "id": "1", "title": "ok",  # no magnet_url at all
+        "season": "1", "episode": "1",
+        "seeds": 10, "peers": 1, "size_bytes": 1024,
+    }]
+    assert th._parse_eztv_json(torrents) == []
+
+
+# ---------------------------------------------------------------------------
+# Security: M3 — IMDB suggestion slug URL-encoding / sanitisation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("hostile_query, expected_in_path", [
+    ("foo/bar",       "foo_bar"),
+    ("foo?x=y",       "foo_x_y"),
+    ("../../etc",     "etc"),
+    ("a&b#c",         "a_b_c"),
+    ("Test Show!",    "test_show"),
+])
+def test_imdb_lookup_candidates_sanitises_path_metacharacters(th, hostile_query, expected_in_path):
+    """Special URL chars in the user query must not survive to the
+    suggestion API path — `?` would inject a query string, `/` and `..`
+    would rewrite the path, `#` would lop off the fragment server-side."""
+    captured = {}
+
+    def fake_get(url, **kwargs):
+        captured["url"] = url
+        resp = MagicMock()
+        resp.json.return_value = {"d": []}
+        return resp
+
+    with patch.object(th.requests, "get", side_effect=fake_get):
+        th._imdb_lookup_candidates(hostile_query)
+
+    url = captured["url"]
+    # Path is .../suggestion/<first>/<slug>.json — both segments must be
+    # alphanumeric (or percent-encoded) and the slug must contain the
+    # expected sanitised form somewhere in it.
+    assert url.startswith("https://v2.sg.media-imdb.com/suggestion/")
+    # `?` and `&` are valid as URL separators only after the path; the
+    # filename portion (.../<slug>.json) must not contain them. `..` would
+    # be path traversal.
+    path_part = url.split("/suggestion/", 1)[1]
+    for bad in ("?", "&", "#", ".."):
+        assert bad not in path_part, f"hostile char '{bad}' leaked into URL path: {url}"
+    assert expected_in_path in url
+
+
+def test_imdb_lookup_candidates_returns_empty_for_only_punctuation(th):
+    """A query that's nothing but punctuation collapses to an empty slug
+    — we must not hit the API with a degenerate URL."""
+    with patch.object(th.requests, "get") as m_get:
+        assert th._imdb_lookup_candidates("???") == []
+        assert th._imdb_lookup_candidates("/.../") == []
+    m_get.assert_not_called()

--- a/tests/test_tpb_parser.py
+++ b/tests/test_tpb_parser.py
@@ -5,6 +5,8 @@ and breaks parsing, these tests will fail loud instead of the tool silently
 returning 0 results.
 """
 
+import pytest
+
 
 def test_parse_tpb_html_returns_ten_results(th, tpb_ubuntu_html):
     results = th._parse_tpb_html(tpb_ubuntu_html, limit=10)
@@ -420,3 +422,48 @@ def test_parse_tpb_html_forces_https_on_absolute_http_links(th):
     assert rows[0]["link"].startswith("https://")
     assert "http://" not in rows[0]["link"]
     assert "thepiratebay.zone/torrent/123/foo" in rows[0]["link"]
+
+
+# --- Security: L2 — apibay info_hash shape ------------------------------
+
+
+def _apibay_record(info_hash):
+    """Minimal apibay record used by the info-hash validation tests."""
+    return {
+        "id": "1",
+        "name": "test",
+        "info_hash": info_hash,
+        "seeders": "10", "leechers": "1", "size": "1024",
+    }
+
+
+@pytest.mark.parametrize("hostile_hash", [
+    "",                                # empty — already rejected, but pin
+    "0" * 40,                          # all-zero sentinel — already rejected
+    "g" * 40,                          # 40 chars but non-hex (g is not hex)
+    "1" * 32,                          # 32 chars but `1` isn't in base32 alphabet
+    "ABC",                             # too short
+    "a" * 41,                          # too long for hex
+    "magnet:?xt=urn:btih:abc",         # outright URL
+    "../../etc/passwd",                # path traversal in case it ever gets joined
+    "abcd ef" + "0" * 33,              # whitespace splice
+])
+def test_parse_apibay_item_rejects_malformed_info_hash(th, hostile_hash):
+    """A buggy or hostile apibay must not produce a magnet URI with a
+    malformed info_hash. The TUI's clipboard / send-to-client actions
+    pass `entry["magnet"]` straight through, so we want this caught at
+    parse time rather than at the user's torrent client."""
+    record = _apibay_record(hostile_hash)
+    assert th.sources.tpb._parse_apibay_item(record) is None
+
+
+@pytest.mark.parametrize("good_hash", [
+    "0123456789abcdef0123456789abcdef01234567",   # 40 hex
+    "ABCDEF0123456789abcdef0123456789ABCDEF01",   # 40 hex mixed case
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567",           # 32 base32
+])
+def test_parse_apibay_item_accepts_valid_info_hash(th, good_hash):
+    record = _apibay_record(good_hash)
+    parsed = th.sources.tpb._parse_apibay_item(record)
+    assert parsed is not None
+    assert good_hash.lower() in parsed["magnet"].lower() or good_hash in parsed["magnet"]

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1429,3 +1429,196 @@ def test_kick_off_rd_no_token_toasts_and_returns_none(reset_state):
     assert state.rd_flow is None
     assert state.mode == RESULTS
     assert "configure-rd" in state.toast or "RD_TOKEN" in state.toast
+
+
+# ── security: URL scheme allowlist on entry actions ───────────────────
+#
+# `entry["link"]` and `entry["magnet"]` come from third-party HTTP
+# responses. `webbrowser.open` dispatches via xdg-open / `open` /
+# os.startfile, all of which happily resolve arbitrary URI schemes
+# against the user's registered handlers. The action helpers must
+# refuse anything that isn't `https://` (page link) or `magnet:?` (magnet).
+
+def _bad_link_entry(scheme):
+    return {
+        "name": "evil",
+        "magnet": "magnet:?xt=urn:btih:" + ("0" * 40),
+        "link": f"{scheme}//attacker.example/x",
+        "source": "TPB",
+        "size": "1 GB", "seeders": 1, "leechers": 1, "ratio": "1.0",
+    }
+
+
+def _bad_magnet_entry(magnet_value):
+    return {
+        "name": "evil",
+        "magnet": magnet_value,
+        "link": "https://example.test/x",
+        "source": "TPB",
+        "size": "1 GB", "seeders": 1, "leechers": 1, "ratio": "1.0",
+    }
+
+
+@pytest.mark.parametrize("scheme", ["http:", "javascript:", "file:", "ftp:", "data:"])
+def test_action_open_page_refuses_non_https_link(reset_state, scheme):
+    """Pressing `o` on a row whose link is not https:// must surface a
+    refusal toast and never call webbrowser.open."""
+    from torrent_hound.tui import _action_open_page
+    entry = _bad_link_entry(scheme)
+    with patch("torrent_hound.tui.webbrowser.open") as m_open:
+        msg = _action_open_page(entry)
+    m_open.assert_not_called()
+    assert "Refused" in msg
+
+
+def test_action_open_page_allows_https_link(reset_state):
+    from torrent_hound.tui import _action_open_page
+    entry = {"link": "https://example.test/torrent/1"}
+    with patch("torrent_hound.tui.webbrowser.open") as m_open:
+        _action_open_page(entry)
+    m_open.assert_called_once_with("https://example.test/torrent/1", new=2)
+
+
+@pytest.mark.parametrize("magnet", [
+    "file:///etc/passwd",
+    "javascript:alert(1)",
+    "https://attacker.example/x",
+    "slack://team/x",
+    "",
+    None,
+])
+def test_action_send_to_client_refuses_non_magnet(reset_state, magnet):
+    """Pressing `d` on a row whose `magnet` field isn't a real magnet:?
+    URI must refuse — `webbrowser.open` would otherwise dispatch the URI
+    to whatever handler the OS has registered for that scheme."""
+    from torrent_hound.tui import _action_send_to_client
+    entry = _bad_magnet_entry(magnet)
+    with patch("torrent_hound.tui.webbrowser.open") as m_open:
+        msg = _action_send_to_client(entry)
+    m_open.assert_not_called()
+    assert "Refused" in msg
+
+
+def test_action_send_to_client_allows_magnet(reset_state):
+    from torrent_hound.tui import _action_send_to_client
+    magnet = "magnet:?xt=urn:btih:" + ("a" * 40)
+    with patch("torrent_hound.tui.webbrowser.open") as m_open:
+        _action_send_to_client({"magnet": magnet})
+    m_open.assert_called_once_with(magnet, new=2)
+
+
+@pytest.mark.parametrize("magnet", [
+    "file:///etc/passwd",
+    "javascript:alert(1)",
+    "https://attacker.example/x",
+    "",
+])
+def test_action_copy_refuses_non_magnet(reset_state, magnet):
+    """Defence in depth — refuse to copy non-magnet content to the clipboard
+    so the user can't paste a hostile URI into their torrent client."""
+    from torrent_hound.tui import _action_copy
+    with patch("torrent_hound.tui.pyperclip.copy") as m_copy:
+        msg = _action_copy({"magnet": magnet})
+    m_copy.assert_not_called()
+    assert "Refused" in msg
+
+
+def test_action_copy_allows_magnet(reset_state):
+    from torrent_hound.tui import _action_copy
+    magnet = "magnet:?xt=urn:btih:" + ("b" * 40)
+    with patch("torrent_hound.tui.pyperclip.copy") as m_copy:
+        msg = _action_copy({"magnet": magnet})
+    m_copy.assert_called_once_with(magnet)
+    assert "copied" in msg.lower()
+
+
+def test_action_seedr_refuses_non_magnet(reset_state):
+    from torrent_hound.tui import _action_seedr
+    with patch("torrent_hound.tui.pyperclip.copy") as m_copy, \
+         patch("torrent_hound.tui.webbrowser.open") as m_open:
+        msg = _action_seedr({"magnet": "javascript:alert(1)"})
+    m_copy.assert_not_called()
+    m_open.assert_not_called()
+    assert "Refused" in msg
+
+
+def test_action_seedr_allows_magnet(reset_state):
+    from torrent_hound.tui import _action_seedr
+    magnet = "magnet:?xt=urn:btih:" + ("c" * 40)
+    with patch("torrent_hound.tui.pyperclip.copy") as m_copy, \
+         patch("torrent_hound.tui.webbrowser.open") as m_open:
+        _action_seedr({"magnet": magnet})
+    m_copy.assert_called_once_with(magnet)
+    m_open.assert_called_once_with("https://www.seedr.cc", new=2)
+
+
+# ── security: ANSI/control char stripping in render boundaries ────────
+#
+# Names, magnets, and free-form metadata fields come from third-party
+# scrapes. `rich.text.Text(plain)` does not escape ESC sequences, so a
+# hostile uploader could repaint header chrome around the rendered cell.
+
+def test_selected_info_line_strips_ansi_from_name(reset_state):
+    """`selected: <source> · <name>` must not pass through ANSI escapes
+    that an uploader put in the torrent name."""
+    from rich.console import Console
+
+    from torrent_hound.tui import _selected_info_line
+    state_module.results = [{
+        "name": "clean\x1b[2J\x1b[Hpwn",
+        "source": "TPB",
+        "magnet": "magnet:?xt=urn:btih:" + ("0" * 40),
+        "link": "https://x.test/1",
+        "size": "1 GB", "seeders": 1, "leechers": 1, "ratio": "1.0",
+    }]
+    state = _AppState(mode=RESULTS, selected_idx=0)
+    line = _selected_info_line(state)
+    buf = Console(record=True, width=200, height=4)
+    buf.print(line)
+    raw = buf.export_text(styles=False)
+    assert "\x1b" not in raw
+    assert "cleanpwn" in raw
+
+
+def test_render_magnet_panel_strips_ansi_from_magnet_text(reset_state):
+    from rich.console import Console
+
+    from torrent_hound.tui import render_magnet_panel
+    state = _AppState(
+        mode=MAGNET_VIEW,
+        magnet_view_text="magnet:?xt=urn:btih:abc&dn=\x1b[31mevil\x1b[0m",
+        magnet_view_name="title \x1b[2Jspoof",
+    )
+    panel = render_magnet_panel(state)
+    buf = Console(record=True, width=120, height=20)
+    buf.print(panel)
+    raw = buf.export_text(styles=False)
+    assert "\x1b" not in raw
+
+
+def test_render_metadata_panel_strips_ansi_from_summary_and_misc(reset_state):
+    """Free-form metadata strings (summary, misc values, uploader, …) must
+    pass through `_strip_ansi` before rich gets a chance to render them
+    verbatim."""
+    from rich.console import Console
+
+    from torrent_hound.tui import render_metadata_panel
+    entry = {
+        "source": "TPB",
+        "size": "1 GB", "seeders": 1, "leechers": 1, "link": "x",
+        "metadata": {
+            "name": "x",
+            "uploader": "evil\x1b[31m_uploader\x1b[0m",
+            "summary": "before\x1b[2J\x1b[Happaren­tly clean",
+            "misc": {
+                "key\x1b[1m": "val\x1b[2Jue",
+            },
+        },
+    }
+    state = _AppState(mode=METADATA_VIEW, metadata_view_entry=entry)
+    panel = render_metadata_panel(state)
+    buf = Console(record=True, width=160, height=40)
+    buf.print(panel)
+    raw = buf.export_text(styles=False)
+    assert "\x1b" not in raw
+    assert "evil_uploader" in raw

--- a/torrent_hound/sources/base.py
+++ b/torrent_hound/sources/base.py
@@ -84,13 +84,20 @@ def _https_get(url, *, headers=None, timeout=8, max_redirects=10):
     """`requests.get` that follows redirects without ever downgrading to
     plaintext.
 
-    Initial URL must be `https://`. Any `http://` in a Location header is
-    rewritten to `https://` before following — defends against servers
-    whose redirect chains transit port 80 (TPB does this: an https request
-    gets a 302 with `Location: http://...` which then 301s back to https,
-    landing one round-trip on plaintext if `requests`'s default
-    follow-anything-anywhere behaviour is used). Other non-https schemes
-    (`file://`, `ftp://`, etc.) raise `InvalidURL`.
+    Initial URL must be `https://`. The redirect policy is:
+
+    * Same-host `http://` → rewritten to `https://` before following.
+      This is the documented TPB case: an https request gets a 302 with
+      `Location: http://thepiratebay.org/...` which then 301s back to
+      https, landing one round-trip on plaintext if `requests`'s default
+      follow-anything-anywhere behaviour is used.
+    * Cross-host `http://` → refused. A hostile or MITM'd mirror could
+      otherwise redirect us at any host of its choosing; the unconditional
+      rewrite that earlier versions performed silently widened the
+      redirect target set instead of restricting it.
+    * `https://` (any host) → followed unchanged. Cross-host https hops
+      are legitimate (e.g. `yts.lt` → `yts.bz`).
+    * Anything else (`file://`, `ftp://`, …) → `InvalidURL`.
 
     Otherwise behaves like `requests.get(allow_redirects=True)` —
     `RequestException` subclasses surface unchanged for callers that
@@ -107,6 +114,12 @@ def _https_get(url, *, headers=None, timeout=8, max_redirects=10):
         if r.status_code in (301, 302, 303, 307, 308) and r.headers.get("Location"):
             loc = _urllib_parse.urljoin(url, r.headers["Location"])
             if loc.startswith("http://"):
+                current_host = _urllib_parse.urlparse(url).hostname
+                target_host = _urllib_parse.urlparse(loc).hostname
+                if current_host != target_host:
+                    raise _requests.exceptions.InvalidURL(
+                        f"refusing cross-host http redirect: {loc}"
+                    )
                 loc = "https://" + loc[len("http://"):]
             elif not loc.startswith("https://"):
                 raise _requests.exceptions.InvalidURL(

--- a/torrent_hound/sources/eztv.py
+++ b/torrent_hound/sources/eztv.py
@@ -1,6 +1,7 @@
 """EZTV source: TV shows via IMDB ID bridge, JSON API, episode/quality filtering."""
 
 import re
+import urllib.parse
 
 import requests
 
@@ -61,10 +62,20 @@ def _imdb_lookup_candidates(query, timeout=8, limit=5):
     others. Returns an empty list on any failure (network / non-JSON /
     no tvSeries match).
     """
-    slug = query.strip().replace(' ', '_').lower()
+    # Restrict the slug to `[a-z0-9_]` and percent-encode it before
+    # interpolation: the slug ends up in the URL path between two `/`
+    # segments, so a stray `?` / `&` / `#` / `/` / `..` would either
+    # rewrite the path (path traversal) or sprout a query string. The
+    # IMDB suggestion API ignores diacritics anyway, so lossy
+    # alphanumeric collapse is what users already get.
+    slug = re.sub(r'[^a-z0-9]+', '_', query.lower()).strip('_')
     if not slug:
         return []
-    url = f'https://v2.sg.media-imdb.com/suggestion/{slug[0]}/{slug}.json'
+    url = (
+        f'https://v2.sg.media-imdb.com/suggestion/'
+        f'{urllib.parse.quote(slug[0], safe="")}/'
+        f'{urllib.parse.quote(slug, safe="")}.json'
+    )
     try:
         r = _https_get(url, timeout=timeout)
         out = []
@@ -94,7 +105,14 @@ def _eztv_slug(title):
 
 
 def _parse_eztv_json(torrents, domain='eztvx.to', season=None, episode=None, filters=None, limit=10):
-    """Filter and convert raw EZTV torrent dicts into our standard result format."""
+    """Filter and convert raw EZTV torrent dicts into our standard result format.
+
+    Drops rows whose `magnet_url` doesn't carry a real `magnet:?...` URI —
+    the field is consumed verbatim by the TUI's `c`/`d`/`cs` actions and
+    eventually passed to `webbrowser.open` (default torrent client) or the
+    user's clipboard, so a hostile or compromised mirror can't sneak a
+    `file://` / `javascript:` / vendor-URI scheme through.
+    """
     parsed = []
     for t in torrents:
         # Season / episode filter
@@ -108,6 +126,9 @@ def _parse_eztv_json(torrents, domain='eztvx.to', season=None, episode=None, fil
             title_lower = title.lower()
             if not all(f in title_lower for f in filters):
                 continue
+        magnet = t.get('magnet_url', '')
+        if not (isinstance(magnet, str) and magnet.startswith('magnet:?')):
+            continue
         seeds = t.get('seeds', 0)
         peers = t.get('peers', 0)
         try:
@@ -143,7 +164,7 @@ def _parse_eztv_json(torrents, domain='eztvx.to', season=None, episode=None, fil
             'leechers': peers,
             'size': _format_bytes(size_bytes),
             'ratio': ratio,
-            'magnet': t.get('magnet_url', ''),
+            'magnet': magnet,
             'metadata': metadata,
         })
         if len(parsed) >= limit:

--- a/torrent_hound/sources/tpb.py
+++ b/torrent_hound/sources/tpb.py
@@ -89,6 +89,13 @@ def _tpb_page_is_empty_results(html) -> bool:
 # layout parser to identify which td holds the size.
 _SIZE_CELL_RE = re.compile(r'^\d+(?:\.\d+)?\s*[KMGT]i?B$', re.IGNORECASE)
 
+# A BT info-hash is either 40 hex chars (BTIH v1) or 32 base32 chars (BTIH
+# v1 alternate encoding). Validating the apibay-supplied value before
+# splicing it into the magnet URI keeps a hostile or buggy upstream from
+# producing a malformed magnet that the TUI's clipboard / send-to-client
+# actions then hand to the user's torrent client unchanged.
+_INFOHASH_RE = re.compile(r'^([0-9a-fA-F]{40}|[A-Za-z2-7]{32})$')
+
 
 def _parse_tpb_html(html, domain='thepiratebay.zone', limit=10):
     """Parse a TPB search-results HTML document. Returns [] if the expected
@@ -232,6 +239,8 @@ def _parse_apibay_item(item):
     name = (item.get('name') or '').strip()
     item_id = item.get('id') or ''
     if not info_hash or not name or info_hash == '0' * 40 or item_id == '0':
+        return None
+    if not _INFOHASH_RE.match(info_hash):
         return None
     try:
         seeders = int(item.get('seeders', 0))

--- a/torrent_hound/tui.py
+++ b/torrent_hound/tui.py
@@ -31,6 +31,7 @@ import termios
 import threading
 import time
 import tty
+import urllib.parse
 import webbrowser
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -326,23 +327,57 @@ def read_key() -> str:
 
 # ── action handlers ────────────────────────────────────────────────────
 # Each returns the toast message to surface; rendering is the loop's job.
+#
+# `entry["link"]` and `entry["magnet"]` originate from third-party HTTP
+# responses (HTML scraped from a TPB mirror, JSON from apibay/YTS/EZTV).
+# `webbrowser.open` dispatches via xdg-open / `open` / os.startfile, which
+# happily resolve arbitrary URI schemes against the user's registered
+# handlers — `file://` discloses local files; `javascript:` may execute;
+# vendor URI handlers (Slack, Zoom, ms-search, …) have shipped RCE bugs.
+# The same allowlist pattern that `_rd_dispatch` uses on Real-Debrid
+# direct-download links is applied here on row links and magnets.
+def _is_safe_https_url(s) -> bool:
+    if not isinstance(s, str):
+        return False
+    try:
+        return urllib.parse.urlparse(s).scheme == "https"
+    except ValueError:
+        return False
+
+
+def _is_safe_magnet(s) -> bool:
+    return isinstance(s, str) and s.startswith("magnet:?")
+
+
 def _action_copy(entry) -> str:
-    pyperclip.copy(str(entry["magnet"]))
+    magnet = entry.get("magnet", "")
+    if not _is_safe_magnet(magnet):
+        return "Refused to copy: row magnet is missing or not a magnet: URI"
+    pyperclip.copy(str(magnet))
     return "Magnet copied to clipboard"
 
 
 def _action_open_page(entry) -> str:
-    webbrowser.open(entry["link"], new=2)
+    link = entry.get("link", "")
+    if not _is_safe_https_url(link):
+        return "Refused to open: row link is not an https:// URL"
+    webbrowser.open(link, new=2)
     return "Opened torrent page in browser"
 
 
 def _action_send_to_client(entry) -> str:
-    webbrowser.open(entry["magnet"], new=2)
+    magnet = entry.get("magnet", "")
+    if not _is_safe_magnet(magnet):
+        return "Refused to dispatch: row magnet is missing or not a magnet: URI"
+    webbrowser.open(magnet, new=2)
     return "Magnet sent to default torrent client"
 
 
 def _action_seedr(entry) -> str:
-    pyperclip.copy(str(entry["magnet"]))
+    magnet = entry.get("magnet", "")
+    if not _is_safe_magnet(magnet):
+        return "Refused to copy: row magnet is missing or not a magnet: URI"
+    pyperclip.copy(str(magnet))
     webbrowser.open("https://www.seedr.cc", new=2)
     return "Magnet copied + Seedr opened"
 
@@ -731,7 +766,9 @@ def _selected_info_line(state: _AppState) -> Text:
         return Text("(no row selected)", style=PALETTE["metadata"])
     source = entry.get("source", "?")
     source_style = SOURCE_COLOURS.get(source, PALETTE["headline"])
-    name = entry.get("name", "")
+    # Untrusted: torrent name comes from a third-party scrape and may carry
+    # ANSI escapes that would otherwise rewrite header chrome around it.
+    name = _strip_ansi(entry.get("name", ""))
     return Text.assemble(
         ("selected: ", PALETTE["metadata"]),
         (source, source_style),
@@ -893,8 +930,12 @@ def render_empty_state(state: _AppState) -> Text:
 
 def render_magnet_panel(state: _AppState) -> Panel:
     """Full-magnet overlay shown when the user presses `m`."""
-    body = Text(state.magnet_view_text, style=PALETTE["accent"], overflow="fold")
-    title_name = state.magnet_view_name[:80]
+    # Both fields are untrusted (the dn parameter and the torrent name come
+    # from a third-party scrape; BeautifulSoup decodes &#x1b; entities to a
+    # literal ESC). Strip ANSI/C0 controls before rendering so a hostile
+    # uploader can't repaint the panel chrome.
+    body = Text(_strip_ansi(state.magnet_view_text), style=PALETTE["accent"], overflow="fold")
+    title_name = _strip_ansi(state.magnet_view_name)[:80]
     return Panel(
         body,
         title=Text(f"magnet · {title_name}", style=PALETTE["headline"]),
@@ -981,9 +1022,15 @@ _METADATA_FIELD_ORDER = [
 def _format_metadata_value(key: str, md: dict, entry: dict) -> str:
     """Per-field rendering. `key` matches the canonical order above; some
     keys are synthesised from the entry (size, seed_leech) rather than the
-    metadata dict."""
+    metadata dict.
+
+    Free-form string fields (uploader description, name, summary, …) come
+    from third-party HTTP responses and are stripped of ANSI/C0 controls
+    before being handed to rich, which otherwise renders them verbatim.
+    Numeric / bool / synthesised fields don't need stripping.
+    """
     if key == "size":
-        return entry.get("size") or "—"
+        return _strip_ansi(entry.get("size") or "—")
     if key == "seed_leech":
         s = entry.get("seeders", "?")
         leech = entry.get("leechers", "?")
@@ -992,7 +1039,9 @@ def _format_metadata_value(key: str, md: dict, entry: dict) -> str:
     if val is None or val == "":
         return "—"
     if key == "imdb_code":
-        url = f"https://www.imdb.com/title/{val}/"
+        # imdb_code is matched against `tt\d+` upstream, so ANSI here would be
+        # a parser bug; defending anyway since this string flows into a Text.
+        url = f"https://www.imdb.com/title/{_strip_ansi(str(val))}/"
         rating = md.get("imdb_rating")
         if rating:
             return f"{url} (★ {rating})"
@@ -1001,7 +1050,7 @@ def _format_metadata_value(key: str, md: dict, entry: dict) -> str:
         return "yes" if val else "no"
     if key in ("season", "episode", "files"):
         return str(val)
-    return str(val)
+    return _strip_ansi(str(val))
 
 
 def render_metadata_panel(state: _AppState) -> Panel:
@@ -1023,7 +1072,8 @@ def render_metadata_panel(state: _AppState) -> Panel:
     if summary:
         body_parts.append(Text(""))
         body_parts.append(Text("Summary:", style=PALETTE["headline"]))
-        body_parts.append(Text(summary, overflow="fold"))
+        # Untrusted uploader prose — strip ANSI/C0 controls before rendering.
+        body_parts.append(Text(_strip_ansi(str(summary)), overflow="fold"))
 
     misc = md.get("misc") or {}
     if misc:
@@ -1033,7 +1083,8 @@ def render_metadata_panel(state: _AppState) -> Panel:
         misc_grid.add_column("k", style=PALETTE["metadata"], no_wrap=True)
         misc_grid.add_column("v", overflow="fold")
         for k, v in misc.items():
-            misc_grid.add_row(k, v)
+            # Both keys and values come from uploader-written description text.
+            misc_grid.add_row(_strip_ansi(str(k)), _strip_ansi(str(v)))
         body_parts.append(misc_grid)
 
     if state.metadata_view_error:


### PR DESCRIPTION
Security review surfaced six issues where third-party HTTP responses
flowed into actions or render paths without enough validation. All have
test coverage; existing 408 tests still pass alongside 51 new ones.

H1 — webbrowser.open without URL-scheme allowlist (HIGH).
  `o`/`d`/`cs` actions handed `entry["link"]` and `entry["magnet"]`
  straight to webbrowser.open, which dispatches via xdg-open / `open` /
  os.startfile — happily resolving file://, javascript:, vendor URI
  handlers (which have shipped RCE bugs). Added allowlists mirroring
  _rd_dispatch: `o` requires https://, `c`/`d`/`cs` require magnet:?.

H2 — ANSI/C0 controls passed through to the terminal (MEDIUM-HIGH).
  Magnet view, metadata panel (summary, misc, uploader, …) and the
  selected-info header line rendered third-party strings via
  rich.text.Text without escape stripping. BeautifulSoup decodes
  &#x1b; entities to literal ESC, so a hostile uploader could repaint
  panel chrome around the rendered cell. Reused `_strip_ansi`.

M1 — EZTV `magnet_url` accepted without scheme check.
  Compromised mirror could ride a non-magnet URI into the user's
  clipboard / torrent client. Drop rows whose magnet_url isn't `magnet:?`.

M2 — `_https_get` widened redirect targets via http→https rewrite.
  Cross-host http redirects were silently rewritten to https — a hostile
  mirror could redirect us at any host of its choosing. Restricted the
  rewrite to same-host; cross-host http now raises InvalidURL. Same-host
  http→https (the documented TPB case) and cross-host https (the
  documented YTS yts.lt → yts.bz hop) still work.

M3 — IMDB suggestion slug interpolated into URL path without encoding.
  `?` / `&` / `#` / `..` in a query rewrote the suggestion API path.
  Slug now collapses to `[a-z0-9_]` and is percent-encoded.

L2 — apibay info_hash not shape-validated.
  Malformed hash from a buggy/hostile upstream produced malformed
  magnets that the TUI passed through to the user's torrent client.
  Validated against `[0-9a-fA-F]{40}|[A-Za-z2-7]{32}` at parse time.